### PR TITLE
Includes Font Awesome assets automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This addon:
 
 ```bash
 # In your application's directory:
-$ npm install --save-dev ember-cli-font-awesome
-# Upgrade notice: from v0.1.0 onwards, you must install Font Awesome dependency manually.
-$ bower install --save-dev font-awesome
+$ ember install ember-cli-font-awesome
 ```
 
 If you have used `npm install` to install the addon, or have manually added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ $ npm install --save-dev ember-cli-font-awesome
 # Upgrade notice: from v0.1.0 onwards, you must install Font Awesome dependency manually.
 $ bower install --save-dev font-awesome
 ```
+
+If you have used `npm install` to install the addon, or have manually added
+`ember-cli-font-awesome` to your `package.json`:
+
+```bash
+ember generate ember-cli-font-awesome
+```
+
 ### Compatibility
 
 Note that from v0.1.0 onwards, this addon will require Ember v1.13 and has only been tested with Ember CLI v1.13.1.

--- a/blueprints/ember-cli-font-awesome/index.js
+++ b/blueprints/ember-cli-font-awesome/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('font-awesome', '~4.3.0');
+  }
+};

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,5 +14,6 @@ module.exports = function(defaults) {
   */
 
   app.import("bower_components/bootstrap/dist/css/bootstrap.css");
+
   return app.toTree();
 };


### PR DESCRIPTION
When installing the plugin it will now automate:
  - Add font-awesome as a bower dependency on install
  - Include the assets in the build when using `ember build` or `ember server`.

I updated the README accordingly.